### PR TITLE
 Increase compatibility with different file systems

### DIFF
--- a/examples/Unit_RFID_M5Core/Unit_RFID_M5Core.ino
+++ b/examples/Unit_RFID_M5Core/Unit_RFID_M5Core.ino
@@ -19,7 +19,7 @@ How to use: / 如何使用
 #include <M5Stack.h>
 #include <M5GFX.h>
 
-#include "Unit_UHF_RFID.h"
+#include "UNIT_UHF_RFID.h"
 
 M5GFX display;
 M5Canvas canvas(&display);

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=See more on https://docs.m5stack.com/en/unit/uhf_rfid
 category=Device Control
 url=https://github.com/m5stack/M5Unit-UHF-RFID
 architectures=esp32
-includes=Unit_UHF-RFID.h
+includes=UNIT_UHF_RFID.h

--- a/src/UNIT_UHF_RFID.cpp
+++ b/src/UNIT_UHF_RFID.cpp
@@ -1,4 +1,4 @@
-#include "Unit_UHF_RFID.h"
+#include "UNIT_UHF_RFID.h"
 #include "CMD.h"
 
 String hex2str(uint8_t num) {


### PR DESCRIPTION
Compilation on an ext4 file system fails because it cannot include the header files since it is a case-sensitive file system.

This PR fixes this issue.
